### PR TITLE
Update Ehrensache Walz links and contact info

### DIFF
--- a/app/routes/alumni/route.tsx
+++ b/app/routes/alumni/route.tsx
@@ -158,8 +158,13 @@ export default function Alumni() {
               </p>
               <p>
                 Für Fragen zu der Initiative, Spenden und der steuerlichen
-                Absetzbarkeit steht{' '}
-                <strong className="text-primary">Mateja Ostrogonac</strong>{' '}
+                Absetzbarkeit stehen wir unter{' '}
+                <a
+                  href="mailto:office@walz.at"
+                  className="text-primary underline underline-offset-4 hover:text-primary/80"
+                >
+                  office@walz.at
+                </a>{' '}
                 gerne zur Verfügung.
               </p>
             </div>

--- a/app/routes/aufnahme+/_index.tsx
+++ b/app/routes/aufnahme+/_index.tsx
@@ -224,10 +224,27 @@ export default function Aufnahme() {
           </h1>
           <div className="mb-8 max-w-prose space-y-4 text-base md:text-xl">
             <p>
-              Durch private Sponsoren steht der Walz ein gewisser Betrag für
-              Stipendien zur Verfügung. Dieser Betrag wird auf mehrere
-              Jugendliche aufgeteilt. Im Bedarfsfall kann ein Antrag (inkl.
-              Einkommensnachweise und Begründung) gestellt werden.
+              Durch private Sponsoren und der Initiative{' '}
+              <Link
+                to="/alumni#ehrensache"
+                className="text-primary underline underline-offset-4 hover:text-primary/80"
+              >
+                „Ehrensache Walz"
+              </Link>{' '}
+              steht der Walz ein gewisser Betrag für Stipendien zur Verfügung.
+              Dieser Betrag wird auf mehrere Jugendliche aufgeteilt. Im
+              Bedarfsfall kann ein Antrag (inkl. Einkommensnachweise und
+              Begründung) gestellt werden.
+            </p>
+            <p>
+              Hierfür melde dich mit deiner Anfrage bitte an{' '}
+              <a
+                href="mailto:office@walz.at"
+                className="text-primary underline underline-offset-4 hover:text-primary/80"
+              >
+                office@walz.at
+              </a>
+              .
             </p>
           </div>
         </article>

--- a/app/routes/unterstuetzende/route.tsx
+++ b/app/routes/unterstuetzende/route.tsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router'
+
 export default function Unterstuetzer() {
   return (
     <div className="relative grid grid-cols-subgrid items-start gap-8 lg:col-span-2">
@@ -8,8 +10,14 @@ export default function Unterstuetzer() {
         <div className="col-span-12 grid grid-cols-subgrid gap-y-12 text-base md:text-xl">
           <p className="col-span-12 max-w-2xl text-body-md">
             Die Walz ist ein gemeinnütziger Verein und finanziert sich
-            überwiegend über Schulgeld. Ein besonderer Dank gilt Ehrensache
-            Walz: Durch das Engagement von Eltern und Ehemaligen können wir
+            überwiegend über Schulgeld. Ein besonderer Dank gilt{' '}
+            <Link
+              to="/alumni#ehrensache"
+              className="text-primary underline underline-offset-4 hover:text-primary/80"
+            >
+              Ehrensache Walz
+            </Link>
+            : Durch das Engagement von Eltern und Ehemaligen können wir
             Teil- und Vollstipendien anbieten, die es Jugendlichen unabhängig
             der finanziellen Situation ihrer Eltern ermöglichen, die Walz zu
             besuchen. Zusätzlich danken wir unseren Förderern für ihre


### PR DESCRIPTION
- **Aufnahme/Stipendien**: Link 'Ehrensache Walz' to alumni section, add office@walz.at contact
- **Unterstützende**: Link 'Ehrensache Walz' to alumni section  
- **Alumni**: Replace Mateja Ostrogonac with office@walz.at