### PR TITLE
Update Aufnahmetermin infobox and confirmation email

### DIFF
--- a/app/routes/aufnahme+/_index.tsx
+++ b/app/routes/aufnahme+/_index.tsx
@@ -344,9 +344,9 @@ function AdmissionDay() {
       </div>
       <div className="space-y-4 text-body-sm/normal">
         <p>
-          Für einen Aufnahmetermin für den Jahrgang Epsilon (9. Schulstufe,
-          Schulbeginn September 2026) fülle das Aufnahmeformular aus. Weitere
-          Infos folgen per Mail.
+          Der Jahrgang Epsilon (9. Schulstufe, Schulbeginn September 2026) ist
+          voll. Für die Aufnahme in den Jahrgang Zeta (Schulbeginn September
+          2027) fülle das Aufnahmeformular aus. Weitere Infos folgen per Mail.
         </p>
         <Button asChild>
           <Link to="/aufnahme/formular">Zum Anmeldeformular</Link>

--- a/app/utils/email.server.ts
+++ b/app/utils/email.server.ts
@@ -37,7 +37,7 @@ export async function sendAufnahmeConfirmationEmail(
 
 vielen Dank für die Zusendung des Aufnahmeformulars!
 
-Nach unserem Tag der offenen Tür am 15.11. wird sich Frauke Rätz telefonisch bei Ihnen, liebe Eltern, melden, um einen Termin für das persönliche Aufnahmegespräch zu vereinbaren.
+Nach unserem Tag der offenen Tür am 14.11.2026 wird sich Frauke Rätz telefonisch bei Ihnen, liebe Eltern, melden, um einen Termin für das persönliche Aufnahmegespräch zu vereinbaren.
 
 Für dich, liebe:r Bewerber:in, bis zum Gespräch:
 • Schicke bitte eine kurze E-Mail an agnes.chorherr@walz.at mit drei Gründen, warum du in die Walz gehen möchtest.


### PR DESCRIPTION
- Infobox: Epsilon ist voll, Zeta (September 2027) beworben
- E-Mail: Tag der offenen Tür auf 14.11.2026 aktualisiert