### PR TITLE
Fix Playwright install hang on Node 24.16 CI runners

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,6 +86,7 @@ jobs:
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1
       - name: 📥 Install Playwright Browsers
+        timeout-minutes: 10
         run: npm run test:e2e:install
       - name: 🏗 Build
         run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
       },
       "devDependencies": {
         "@epic-web/config": "^1.21.3",
-        "@playwright/test": "^1.55.1",
+        "@playwright/test": "^1.60.0",
         "@react-router/dev": "^7.9.3",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.0",
@@ -4444,13 +4444,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -18204,13 +18204,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -18223,9 +18223,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@epic-web/config": "^1.21.3",
-    "@playwright/test": "^1.55.1",
+    "@playwright/test": "^1.60.0",
     "@react-router/dev": "^7.9.3",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.0",


### PR DESCRIPTION
## Problem
Both Playwright CI runs since #119 hung indefinitely at "Install Playwright Browsers" (60-min job timeout), which blocks `deploy` — main cannot ship until this passes.

## Root cause
The job log shows the chromium download completing (100%) at 15:56, then 58 minutes of silence until timeout — apt never ran. This matches a documented upstream bug:

- Node **24.16.0** (what `node-version: 24` resolves to since the Node bump) regressed ([nodejs/node#63495](https://github.com/nodejs/node/issues/63495)) in a way that silently kills Playwright's yauzl extraction worker; the parent `playwright install` waits forever on stale IPC pipes ([microsoft/playwright#40998](https://github.com/microsoft/playwright/issues/40998), [#41092](https://github.com/microsoft/playwright/issues/41092)).
- Affects Playwright **< 1.60.0**; fixed upstream in **1.60.0**.
- Last green run (May 12) used Node 22; local Node 24.11 also unaffected — only ≥24.16 bites.

## Fix
- Bump `@playwright/test` 1.58.2 → **1.60.0** (the upstream fix) — keeps CI on Node 24, matching the production Dockerfile.
- Add `timeout-minutes: 10` to the install step so any future hang fails fast instead of eating the 60-minute job.

## Verification
- typecheck, lint-clean files, 21/21 unit tests locally.
- The Playwright job on **this PR's own CI run** is the real test — it previously hung 2/2 at the identical point.
