### PR TITLE
Fix production crash: declare react-is for @sanity/ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "ramda": "^0.32.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-is": "^19.2.7",
         "react-router": "^7.9.3",
         "remix-flat-routes": "^0.8.5",
         "remix-utils": "^9.2.0",
@@ -8499,12 +8500,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/@sanity/cli/node_modules/react-is": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
-      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
-      "license": "MIT"
-    },
     "node_modules/@sanity/cli/node_modules/readdirp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
@@ -8947,12 +8942,6 @@
         "@sanity/types": "*",
         "react": "^19.2"
       }
-    },
-    "node_modules/@sanity/insert-menu/node_modules/react-is": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
-      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
-      "license": "MIT"
     },
     "node_modules/@sanity/json-match": {
       "version": "1.0.5",
@@ -20805,6 +20794,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
@@ -21133,10 +21129,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
       "license": "MIT"
     },
     "node_modules/react-redux": {
@@ -22367,12 +22362,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/sanity/node_modules/react-is": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
-      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
-      "license": "MIT"
     },
     "node_modules/sanity/node_modules/uuid": {
       "version": "11.1.1",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "ramda": "^0.32.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-is": "^19.2.7",
     "react-router": "^7.9.3",
     "remix-flat-routes": "^0.8.5",
     "remix-utils": "^9.2.0",


### PR DESCRIPTION
The housecleaning deploy (#121) failed Fly health checks: the new machine crash-looped with `ERR_MODULE_NOT_FOUND: react-is` from `@sanity/ui` whenever the Studio chunk loaded.

**Why prod-only:** `@sanity/ui` peer-depends on `react-is`; with `legacy-peer-deps=true` npm doesn't install it. Locally an (invalid) `react-is@17` hoisted from `@testing-library` masked it — `npm prune --omit=dev` in the Docker image removes that copy.

**Fix:** `react-is@^19` as a direct dependency (valid for @sanity/ui's `^18 || >=19` range, matches React 19.2.7, survives the prune).

Verified locally on a production build: `/studio` 200, process stays up. Real proof is this deploy.