### PR TITLE
Add /studio e2e smoke test

### DIFF
--- a/tests/studio.spec.ts
+++ b/tests/studio.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test'
+
+// The Studio chunk (@sanity/ui and friends) once crashed the whole server
+// process on import in production (missing react-is, PR #122). This smoke
+// test catches studio-route breakage early: a failed SSR import, a broken
+// sanity config, or a schema error all surface here. Note: CI runs e2e
+// against the dev server, so prune-dependent failures (devDependency
+// masking a missing prod dep) still need the production image to reproduce.
+test.describe('Sanity Studio', () => {
+  test('studio route serves and the server survives it', async ({ page }) => {
+    // the studio bundle is huge; first compile in dev can exceed the
+    // default 15s test timeout
+    test.slow()
+
+    const studio = await page.goto('/studio')
+    expect(studio?.status()).toBe(200)
+
+    // the historical failure killed the server process itself — verify the
+    // app still answers after the studio chunk has been loaded
+    const followUp = await page.goto('/')
+    expect(followUp?.status()).toBe(200)
+  })
+})


### PR DESCRIPTION
Closes the blind spot from the react-is incident (#122): the e2e suite never loaded `/studio`, so a crash in the studio bundle couldn't fail CI.

- Asserts `/studio` serves 200 **and** that the server still answers afterwards (the historical failure killed the whole process)
- `test.slow()` because the studio bundle's first dev-compile runs ~14s against the default 15s test timeout (verified cold-cache locally)
- Red-green verified: with the studio route removed the test fails with `Expected 200, Received 404`
- Honest scope note: CI e2e runs against the **dev server**, so prune-dependent failures (a devDependency masking a missing prod dep, as in #122) still only reproduce in the production image. This test catches the broader class: broken sanity config, schema errors, failed SSR imports.